### PR TITLE
Builtin hash is salted by default post python-3.3; replace with md5.

### DIFF
--- a/chest/core.py
+++ b/chest/core.py
@@ -22,7 +22,7 @@ def key_to_filename(key):
     if isinstance(key, str) and re.match('^[_a-zA-Z]\w*$', key):
         return key
     else:
-        return str(hashlib.md5(key.encode()).hexdigest())
+        return str(hashlib.md5(str(key).encode()).hexdigest())
 
 
 def _do_nothing(*args, **kwargs):

--- a/chest/core.py
+++ b/chest/core.py
@@ -8,7 +8,7 @@ import os
 import re
 import pickle
 from heapdict import heapdict
-
+import hashlib
 
 DEFAULT_AVAILABLE_MEMORY = 1e9
 
@@ -22,7 +22,7 @@ def key_to_filename(key):
     if isinstance(key, str) and re.match('^[_a-zA-Z]\w*$', key):
         return key
     else:
-        return str(abs(hash(key)))
+        return str(hashlib.md5(key.encode()).hexdigest())
 
 
 def _do_nothing(*args, **kwargs):


### PR DESCRIPTION
Salting the hashes screws key_to_filename, making it impossible
to recover chests from different interpreter instances with
python3.3 or later.

hashlib.md5 is a reasonably fast alternative.